### PR TITLE
fix: resolve issues #2, #3, #4 (SHA-NI hashes, bench error check, CUDA loader)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,7 +200,11 @@ test/*
 /test_paf_ext
 /test_paf2*
 *.paf
-/bench/
+/bench/*.exe
+/bench/*.obj
+/bench/*.paf
+/bench/extracted/
+/bench/archives/
 /bench_win_data/
 /build_android/
 /build_linux/

--- a/bench/bench_paf.c
+++ b/bench/bench_paf.c
@@ -1,0 +1,117 @@
+#include "libpaf.h"
+#include "paf_extractor.h"
+#include "paf_gpu.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+static double now_sec(void) {
+    LARGE_INTEGER t, f;
+    QueryPerformanceCounter(&t);
+    QueryPerformanceFrequency(&f);
+    return (double)t.QuadPart / (double)f.QuadPart;
+}
+#else
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+#endif
+
+static void usage(const char* prog) {
+    fprintf(stderr,
+        "Usage:\n"
+        "  %s create   <src_dir>  <out.paf>\n"
+        "  %s extract  <in.paf>   <out_dir>\n"
+        "  %s extract_gpu <in.paf> <out_dir>\n"
+        "  %s info     <in.paf>\n",
+        prog, prog, prog, prog);
+}
+
+static int cmd_create(const char* src_dir, const char* out_paf) {
+    const char* inputs[] = { src_dir };
+    double start = now_sec();
+    int res = paf_create_binary(out_paf, inputs, 1, NULL, 1);
+    double end = now_sec();
+    if (res != 0) {
+        fprintf(stderr, "RESULT: FAIL (paf_create_binary returned %d)\n", res);
+        return 1;
+    }
+    printf("RESULT: OK, Time: %.3f sec\n", end - start);
+    return 0;
+}
+
+static int cmd_extract(const char* paf_path, const char* out_dir) {
+    double start = now_sec();
+    int res = paf_extract_binary(paf_path, out_dir, 1);
+    double end = now_sec();
+    if (res != 0) {
+        fprintf(stderr, "RESULT: FAIL (paf_extract_binary returned %d)\n", res);
+        return 1;
+    }
+    printf("RESULT: OK, Time: %.3f sec\n", end - start);
+    return 0;
+}
+
+static int cmd_extract_gpu(const char* paf_path, const char* out_dir) {
+    paf_extractor_t ext;
+    if (paf_extractor_open(&ext, paf_path) != 0) {
+        fprintf(stderr, "RESULT: FAIL (could not open %s)\n", paf_path);
+        return 1;
+    }
+
+    double start = now_sec();
+    int res = paf_extractor_gpu_run(&ext, paf_path, out_dir);
+    double end = now_sec();
+
+    paf_extractor_close(&ext);
+
+    /* paf_extractor_gpu_run returns 0 on success, negative on error */
+    if (res == 0) {
+        printf("RESULT: OK, Time: %.3f sec\n", end - start);
+        return 0;
+    } else {
+        fprintf(stderr, "RESULT: FAIL (errors %d)\n", -res);
+        return 1;
+    }
+}
+
+static int cmd_info(const char* paf_path) {
+    paf_extractor_t ext;
+    if (paf_extractor_open(&ext, paf_path) != 0) {
+        fprintf(stderr, "Could not open %s\n", paf_path);
+        return 1;
+    }
+    printf("file_count : %u\n", ext.header.file_count);
+    printf("index_offset: %llu\n", (unsigned long long)ext.header.index_offset);
+    printf("path_offset : %llu\n", (unsigned long long)ext.header.path_offset);
+
+    paf_gpu_info_t gpu;
+    paf_gpu_get_info(&gpu);
+    printf("gpu_device : %s\n", gpu.device_name);
+    printf("total_vram : %llu MB\n", (unsigned long long)(gpu.total_vram / 1024 / 1024));
+
+    paf_extractor_close(&ext);
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) { usage(argv[0]); return 1; }
+
+    const char* cmd = argv[1];
+    if (strcmp(cmd, "create") == 0 && argc == 4)
+        return cmd_create(argv[2], argv[3]);
+    if (strcmp(cmd, "extract") == 0 && argc == 4)
+        return cmd_extract(argv[2], argv[3]);
+    if (strcmp(cmd, "extract_gpu") == 0 && argc == 4)
+        return cmd_extract_gpu(argv[2], argv[3]);
+    if (strcmp(cmd, "info") == 0 && argc == 3)
+        return cmd_info(argv[2]);
+
+    usage(argv[0]);
+    return 1;
+}

--- a/libpaf/src/paf_gpu_loader.c
+++ b/libpaf/src/paf_gpu_loader.c
@@ -21,19 +21,35 @@ int paf_gpu_init(void) {
     g_dstorage_avail = 0;
 
     /* --- CUDA --- */
-    HMODULE hcuda = LoadLibraryA("paf_cuda.dll");
-    if (hcuda) {
-        typedef int (*init_fn)(void);
-        init_fn              cuda_init  = (init_fn)             (uintptr_t)GetProcAddress(hcuda, "paf_cuda_init");
-        paf_cuda_hash_flat_fn hash_flat = (paf_cuda_hash_flat_fn)(uintptr_t)GetProcAddress(hcuda, "paf_cuda_hash_flat");
-
-        if (cuda_init && hash_flat && cuda_init() == 0) {
-            g_paf_cuda_hash_flat = hash_flat;
+#ifdef PAF_USE_CUDA
+    /* CUDA kernels are statically linked (paf_cuda_kernels.obj -> libpaf.dll);
+       no external paf_cuda.dll exists, so call the symbols directly. */
+    {
+        extern int paf_cuda_init(void);
+        extern int paf_cuda_hash_flat(const uint8_t*, const uint64_t*, const uint64_t*,
+                                      uint32_t, uint8_t*);
+        if (paf_cuda_init() == 0) {
+            g_paf_cuda_hash_flat = paf_cuda_hash_flat;
             g_cuda_avail = 1;
-        } else {
-            FreeLibrary(hcuda);
         }
     }
+#else
+    {
+        HMODULE hcuda = LoadLibraryA("paf_cuda.dll");
+        if (hcuda) {
+            typedef int (*init_fn)(void);
+            init_fn              cuda_init  = (init_fn)             (uintptr_t)GetProcAddress(hcuda, "paf_cuda_init");
+            paf_cuda_hash_flat_fn hash_flat = (paf_cuda_hash_flat_fn)(uintptr_t)GetProcAddress(hcuda, "paf_cuda_hash_flat");
+
+            if (cuda_init && hash_flat && cuda_init() == 0) {
+                g_paf_cuda_hash_flat = hash_flat;
+                g_cuda_avail = 1;
+            } else {
+                FreeLibrary(hcuda);
+            }
+        }
+    }
+#endif
 
     /* --- DirectStorage --- */
     HMODULE hds = LoadLibraryA("dstorage.dll");

--- a/libpaf/src/paf_sha256_hw.c
+++ b/libpaf/src/paf_sha256_hw.c
@@ -167,22 +167,16 @@ static void paf_sha256_x86ni(const uint8_t* data, size_t len, uint8_t out[32]) {
         for (int i = 16; i < 64; i++)
             W[i] = S1(W[i-2]) + W[i-7] + S0(W[i-15]) + W[i-16];
 
-        // 64 rounds via sha256rnds2 (2 rounds per call, 32 calls total)
+        // 64 rounds: one sha256rnds2 pair per 4-round step.
+        // MSG must carry all four K+W values so shuffle(0x0e) correctly moves
+        // rounds r+2/r+3 into the low dwords for the second call.
         for (int r = 0; r < 64; r += 4) {
-            __m128i MSG = _mm_set_epi32((int)(W[r+1]+SHA256_K[r+1]),
-                                        (int)(W[r  ]+SHA256_K[r  ]),
-                                        (int)(W[r+1]+SHA256_K[r+1]),
-                                        (int)(W[r  ]+SHA256_K[r  ]));
-            // Only low 2 dwords used by sha256rnds2; high 2 are ignored
-            MSG = _mm_set_epi32(0, 0, (int)(W[r+1]+SHA256_K[r+1]), (int)(W[r]+SHA256_K[r]));
-            S1 = _mm_sha256rnds2_epu32(S1, S0, MSG);
-            MSG = _mm_shuffle_epi32(MSG, 0x0e);
-            S0 = _mm_sha256rnds2_epu32(S0, S1, MSG);
-
-            MSG = _mm_set_epi32(0, 0, (int)(W[r+3]+SHA256_K[r+3]), (int)(W[r+2]+SHA256_K[r+2]));
-            S1 = _mm_sha256rnds2_epu32(S1, S0, MSG);
-            MSG = _mm_shuffle_epi32(MSG, 0x0e);
-            S0 = _mm_sha256rnds2_epu32(S0, S1, MSG);
+            __m128i MSG = _mm_set_epi32(
+                (int)(W[r+3]+SHA256_K[r+3]), (int)(W[r+2]+SHA256_K[r+2]),
+                (int)(W[r+1]+SHA256_K[r+1]), (int)(W[r  ]+SHA256_K[r  ]));
+            S1 = _mm_sha256rnds2_epu32(S1, S0, MSG);   /* rounds r,   r+1 → CDGH */
+            MSG = _mm_shuffle_epi32(MSG, 0x0e);          /* move r+2/r+3 to low dwords */
+            S0 = _mm_sha256rnds2_epu32(S0, S1, MSG);   /* rounds r+2, r+3 → ABEF */
         }
 
         S0 = _mm_add_epi32(S0, sv0);
@@ -190,13 +184,17 @@ static void paf_sha256_x86ni(const uint8_t* data, size_t len, uint8_t out[32]) {
     }
     free(buf);
 
-    // Rearrange: S0={A,B,E,F}, S1={C,D,G,H} → digest order ABCDEFGH
-    __m128i tmp = _mm_shuffle_epi32(S0, 0x1b);  // {F,E,B,A}
-    S1          = _mm_shuffle_epi32(S1, 0xb1);  // {D,C,H,G}
-    S0          = _mm_blend_epi16(tmp, S1, 0xf0); // {D,C,B,A}
-    S1          = _mm_alignr_epi8(S1, tmp, 8);    // {H,G,F,E}
-    _mm_storeu_si128((__m128i*)out,      S0);
-    _mm_storeu_si128((__m128i*)(out+16), S1);
+    // Rearrange S0={A,B,E,F}, S1={C,D,G,H} into digest byte order ABCDEFGH,
+    // then byte-swap each 32-bit word to produce big-endian output (matching
+    // the generic and ARM implementations).
+    __m128i tmp = _mm_shuffle_epi32(S0, 0x1b);       /* {F,E,B,A} dword[3..0] */
+    S1          = _mm_shuffle_epi32(S1, 0xb1);        /* {D,C,H,G} */
+    S0          = _mm_blend_epi16(tmp, S1, 0xf0);     /* {D,C,B,A} */
+    S1          = _mm_alignr_epi8(S1, tmp, 8);        /* {H,G,F,E} */
+    /* pshufb mask: reverses bytes within each 32-bit lane (native→big-endian) */
+    const __m128i bswap = _mm_set_epi8(12,13,14,15, 8,9,10,11, 4,5,6,7, 0,1,2,3);
+    _mm_storeu_si128((__m128i*)out,      _mm_shuffle_epi8(S0, bswap));
+    _mm_storeu_si128((__m128i*)(out+16), _mm_shuffle_epi8(S1, bswap));
 }
 #undef ROTR
 #undef S0


### PR DESCRIPTION
## Summary

- **Issue #4** (`paf_gpu_loader.c`): `PAF_USE_CUDA` ビルドでは CUDA カーネルが `libpaf.dll` に静的リンク済みのため `LoadLibraryA("paf_cuda.dll")` が常に失敗していた。`#ifdef PAF_USE_CUDA` ブランチを追加し、`paf_cuda_init` / `paf_cuda_hash_flat` を直接呼ぶよう修正。
- **Issue #2** (`paf_sha256_hw.c`): x86 SHA-NI のラウンドループで MSG に2ワードしか詰めていなかったため、`shuffle(0x0e)` 後に K+W が 0 になり64ラウンドの半分が壊れていた。また出力のバイトスワップが抜けており、ジェネリック・ARM・GPU 実装と出力バイト順が不一致だった。両方を修正。
- **Issue #3** (`bench/bench_paf.c`): ベンチマーク CLI を新規作成。`paf_extractor_gpu_run` は成功時 `0`・失敗時に負値を返すため、`res == 0` で正しく判定するよう実装（`res <= 0` では常に OK になる）。

## Test plan

- [ ] `gcc -O2 -shared -fPIC -Ilibpaf/include libpaf/src/*.c -lpthread -o libpaf.so` でビルドが通ることを確認
- [ ] `test/test_paf.c` の全35テストが通ることを確認
- [ ] Windows GPU ビルド (`build_paf_gpu.ps1`) で CUDA が正しく初期化されることを確認
- [ ] GPU なし環境で `bench_paf extract_gpu` を実行し、ファイルが正しく抽出されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_0158FFZdepfMX1ipWNay44Ug)_